### PR TITLE
Update README.md [apkeep]

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,17 @@ Advanced APK analysis tool with intelligent caching, pattern matching, comprehen
 
 ### Install external tools
 ```bash
+# To Download npm/node
+https://nodejs.org/en/download
+
 # apk-mitm (MITM HTTPS patching)
 npm install -g apk-mitm
 
+# To download cargo/rust
+https://doc.rust-lang.org/cargo/getting-started/installation.html
+
 # apkeep (APK download by package name)
-pip install --upgrade apkeep
+cargo install apkeep
 ```
 
 Notes:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Advanced APK analysis tool with intelligent caching, pattern matching, comprehen
 
 ### Optional but recommended tools
 - Node.js 16+ and npm (for `apk-mitm` if you enable MITM patching)
-- Python 3.8+ and pip (for `apkeep` APK downloader)
+- ruby and cargo latest versio (for `apkeep` APK downloader)
 
 ### Install external tools
 ```bash


### PR DESCRIPTION
apkeep is not exist on pip library it's a rust tool:

```
pip install --upgrade apkeep --break-system-packages
ERROR: Could not find a version that satisfies the requirement apkeep (from versions: none)
ERROR: No matching distribution found for apkeep
```